### PR TITLE
Correct bug on passing parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bizmate-oss/netscan
+module github.com/jessfraz/netscan
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jessfraz/netscan
+module github.com/bizmate-oss/netscan
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/main.go
+++ b/main.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/genuinetools/pkg/cli"
-	"github.com/jessfraz/netscan/pkg/scanner"
-	"github.com/jessfraz/netscan/version"
+	"github.com/bizmate-oss/netscan/pkg/scanner"
+	"github.com/bizmate-oss/netscan/version"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -106,10 +106,9 @@ func (s *Scanner) Scan() []AddressSet {
 	for _, ip := range s.ips {
 		for _, port := range s.ports {
 			for _, proto := range s.protocols {
-				addr := fmt.Sprintf("%s:%d", ip, port)
-
 				wg.Add(1)
-				go func(proto, addr string) {
+				go func(ip net.IP, port int, proto string) {
+					addr := fmt.Sprintf("%s:%d", ip, port)
 					defer wg.Done()
 
 					guard <- struct{}{}
@@ -125,7 +124,7 @@ func (s *Scanner) Scan() []AddressSet {
 						})
 						resultsMutex.Unlock()
 					}
-				}(proto, addr)
+				}(ip, port, proto)
 			}
 		}
 	}


### PR DESCRIPTION
Correct bug on passing parameters to scan thread which prevents to fill correctly the results.

The go func(proto, addr) will use the last ip, proto and port from the loop and not the correct one as for addr.
Changing the way parameters are passed the thread will use the correct ones.